### PR TITLE
[feat]适配 sensor_v2 框架

### DIFF
--- a/inc/sensor_dallas_ds18b20.h
+++ b/inc/sensor_dallas_ds18b20.h
@@ -15,11 +15,6 @@
 #include <rthw.h>
 #include <rtthread.h>
 #include <rtdevice.h>
-#include "drivers/sensor.h"
-
-#if RT_VER_NUM < 0x50000
-#include <stdint.h>
-#endif
 
 #define CONNECT_SUCCESS  0
 #define CONNECT_FAILED   1

--- a/sample/ds18b20_sample.c
+++ b/sample/ds18b20_sample.c
@@ -12,7 +12,8 @@
 #include <stdlib.h>
 #include <rtthread.h>
 #include "board.h"
-#include "drivers/sensor.h"
+#include "rtdevice.h"
+#include "drv_gpio.h"
 #include "sensor_dallas_ds18b20.h"
 
 /* Modify this pin according to the actual wiring situation */
@@ -36,7 +37,7 @@ static void read_temp_entry(void *parameter)
         rt_kprintf("open device failed!\n");
         return;
     }
-    rt_device_control(dev, RT_SENSOR_CTRL_SET_ODR, (void *)100);
+    rt_device_control(dev, RT_SENSOR_CTRL_GET_ID, (void *)100); //always return RT_EOK
 
     while (1)
     {
@@ -51,16 +52,14 @@ static void read_temp_entry(void *parameter)
         {
             if (sensor_data.data.temp >= 0)
             {
-                rt_kprintf("temp:%3d.%dC, timestamp:%5d\n",
-                           sensor_data.data.temp / 10,
-                           sensor_data.data.temp % 10,
+                rt_kprintf("temp:%.2fC, timestamp:%5d\n",
+                           sensor_data.data.temp / 10.0,
                            sensor_data.timestamp);
             }
             else
             {
-                rt_kprintf("temp:-%2d.%dC, timestamp:%5d\n",
-                           abs(sensor_data.data.temp / 10),
-                           abs(sensor_data.data.temp % 10),
+                rt_kprintf("temp:-%.2fC, timestamp:%5d\n",
+                           abs(sensor_data.data.temp / 10.0),
                            sensor_data.timestamp);
             }
         }
@@ -74,7 +73,7 @@ static int ds18b20_read_temp_sample(void)
 
     ds18b20_thread = rt_thread_create("18b20tem",
                                       read_temp_entry,
-                                      "temp_ds18b20",
+                                      "tm-ds18b",
                                       1024,
                                       RT_THREAD_PRIORITY_MAX / 2,
                                       20);
@@ -91,7 +90,7 @@ static int rt_hw_ds18b20_port(void)
 {
     struct rt_sensor_config cfg;
     
-    cfg.intf.user_data = (void *)DS18B20_DATA_PIN;
+    cfg.intf.arg = (void *)DS18B20_DATA_PIN;
     rt_hw_ds18b20_init("ds18b20", &cfg);
     
     return RT_EOK;

--- a/src/sensor_dallas_ds18b20.c
+++ b/src/sensor_dallas_ds18b20.c
@@ -192,7 +192,7 @@ static rt_size_t _ds18b20_polling_get_data(rt_sensor_t sensor, struct rt_sensor_
     return 1;
 }
 
-static rt_size_t ds18b20_fetch_data(struct rt_sensor_device *sensor, void *buf, rt_size_t len)
+static rt_ssize_t ds18b20_fetch_data(rt_sensor_t sensor, rt_sensor_data_t buf, rt_size_t len)
 {
     RT_ASSERT(buf);
 

--- a/src/sensor_dallas_ds18b20.c
+++ b/src/sensor_dallas_ds18b20.c
@@ -10,7 +10,7 @@
  */
 
 #include "sensor_dallas_ds18b20.h"
-#include "drivers/sensor.h"
+#include "rtdevice.h"
 #include "board.h"
 #include <rtdbg.h>
 
@@ -20,11 +20,7 @@
 #define SENSOR_TEMP_RANGE_MAX (125)
 #define SENSOR_TEMP_RANGE_MIN (-55)
 
-#if RT_VER_NUM < 0x50000
-RT_WEAK void rt_hw_us_delay(rt_uint32_t us)
-#else
 rt_weak void rt_hw_us_delay(rt_uint32_t us)
-#endif
 {
     rt_uint32_t delta;
 
@@ -187,9 +183,9 @@ int32_t ds18b20_get_temperature(rt_base_t pin)
 static rt_size_t _ds18b20_polling_get_data(rt_sensor_t sensor, struct rt_sensor_data *data)
 {
     rt_int32_t temperature_x10;
-    if (sensor->info.type == RT_SENSOR_CLASS_TEMP)
+    if (sensor->info.type == RT_SENSOR_TYPE_TEMP)
     {
-        temperature_x10 = ds18b20_get_temperature((rt_base_t)sensor->config.intf.user_data);
+        temperature_x10 = ds18b20_get_temperature((rt_base_t)sensor->config.intf.arg);
         data->data.temp = temperature_x10;
         data->timestamp = rt_sensor_get_ts();
     }    
@@ -200,7 +196,7 @@ static rt_size_t ds18b20_fetch_data(struct rt_sensor_device *sensor, void *buf, 
 {
     RT_ASSERT(buf);
 
-    if (sensor->config.mode == RT_SENSOR_MODE_POLLING)
+    if (sensor->info.mode == RT_SENSOR_MODE_FETCH_POLLING)
     {
         return _ds18b20_polling_get_data(sensor, buf);
     }
@@ -226,21 +222,21 @@ int rt_hw_ds18b20_init(const char *name, struct rt_sensor_config *cfg)
     rt_int8_t result;
     rt_sensor_t sensor_temp = RT_NULL; 
     
-    if (!ds18b20_init((rt_base_t)cfg->intf.user_data))
+    if (!ds18b20_init((rt_base_t)cfg->intf.arg))
     {
         /* temperature sensor register */
         sensor_temp = rt_calloc(1, sizeof(struct rt_sensor_device));
         if (sensor_temp == RT_NULL)
             return -1;
 
-        sensor_temp->info.type       = RT_SENSOR_CLASS_TEMP;
+        sensor_temp->info.type       = RT_SENSOR_TYPE_TEMP;
         sensor_temp->info.vendor     = RT_SENSOR_VENDOR_DALLAS;
-        sensor_temp->info.model      = "ds18b20";
-        sensor_temp->info.unit       = RT_SENSOR_UNIT_DCELSIUS;
+        sensor_temp->info.name      = "ds18b20";
+        sensor_temp->info.unit       = RT_SENSOR_UNIT_CELSIUS;
         sensor_temp->info.intf_type  = RT_SENSOR_INTF_ONEWIRE;
-        sensor_temp->info.range_max  = SENSOR_TEMP_RANGE_MAX;
-        sensor_temp->info.range_min  = SENSOR_TEMP_RANGE_MIN;
-        sensor_temp->info.period_min = 5;
+        sensor_temp->info.scale.range_max  = SENSOR_TEMP_RANGE_MAX;
+        sensor_temp->info.scale.range_min  = SENSOR_TEMP_RANGE_MIN;
+        sensor_temp->info.acquire_min = 5;
 
         rt_memcpy(&sensor_temp->config, cfg, sizeof(struct rt_sensor_config));
         sensor_temp->ops = &sensor_ops;


### PR DESCRIPTION
1. 适配新的 sensor_v2 框架的结构成员名
2. 适配 sensor_v2 框架默认支持浮点数显示输出
3. 适配 sensor_v2 框架采用新的传感器设备前缀名

希望能够 release 一个 V1.0.0 的包，然后适配 sensor_v2 的包从 V2.0.0 开始